### PR TITLE
Fixing devise option

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
 
-  # before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: :index
 
   def index
     @posts = Post.order("created_at DESC").limit(8)

--- a/app/views/shared/_newpost.html.haml
+++ b/app/views/shared/_newpost.html.haml
@@ -2,4 +2,3 @@
   .newitem
     = link_to post_path(p.id) do
       = image_tag(p.image.url)
-


### PR DESCRIPTION
#What
deviseのオプション(authenticate_user)をコメントアウトしていたため、コメントを外す

#Why
ログイン状態にある利用者以外は内容を見れないようにするため