### PR TITLE
Changing back consider all request local production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]


### PR DESCRIPTION
#What
Production.rbのconsider all request localの設定をfalseに戻す

#Why
本番環境でエラーを確認するために一時的にtrueにしていたが、問題が解決ができたのでfalseに戻る。
（本番環境ではローカル環境のようにエラーが確認できないので、この設定を使うことでエラー分が見れるようになる）