### PR TITLE
Slick update

### DIFF
--- a/app/assets/javascripts/slick.js
+++ b/app/assets/javascripts/slick.js
@@ -3,8 +3,8 @@ $(function () {
   $('.slider').slick({
     // slidesToShow: 4,
     // slidesToScroll: 1,
-    // autoplay: true,
-    // autoplaySpeed: 3000,
+    autoplay: true,
+    autoplaySpeed: 3000,
     centerMode: true,
     variableWidth: true,
     dots: true,

--- a/app/assets/stylesheets/slick-theme.scss
+++ b/app/assets/stylesheets/slick-theme.scss
@@ -48,15 +48,15 @@ $slick-opacity-not-active: 0.25 !default;
 }
 
 /* Icons */
-@if $slick-font-family == "slick" {
-    @font-face {
-        font-family: "slick";
-        src: slick-font-url("slick.eot");
-        src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
-        font-weight: normal;
-        font-style: normal;
-    }
-}
+// @if $slick-font-family == "slick" {
+//     @font-face {
+//         font-family: "slick";
+//         src: slick-font-url("slick.eot");
+//         src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
+//         font-weight: normal;
+//         font-style: normal;
+//     }
+// }
 
 /* Arrows */
 


### PR DESCRIPTION
#What
indexのスライドをオンに変更
slickエラーを解決

#Why
slickのfontの読み込みがrailsでは対応していないとの情報があったため
エラーが出ているslick.theme.scssのfont部分をコメントアウトで解消(使用しないため)